### PR TITLE
Adapt main.js code for swiper

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -380,6 +380,10 @@
 	document.addEventListener('DOMContentLoaded', () => {
 		const tabControls = document.querySelector('.keywords-list')
 
+		// Swiper-based filtering setup
+		const productList = document.querySelector('.product-cards-list')
+		const allSlides = productList ? Array.from(productList.children) : []
+
 		tabControls.addEventListener('click', toggleTab)
 
 		function toggleTab(event) {
@@ -396,7 +400,16 @@
 			tabControl.classList.add('keywords-list__item--active')
 		}
 
-		const items = document.querySelectorAll('.product-cards-list')
+		function rebuildSwiperWithSlides(slides) {
+			if (!productList) return
+			if (cardsSwiper) {
+				cardsSwiper.destroy(true, true)
+			}
+			productList.innerHTML = ''
+			slides.forEach(slide => productList.appendChild(slide))
+			initCardsSwiper()
+			updateSwiperFraction()
+		}
 
 		function filterTabs() {
 			tabControls.addEventListener('click', e => {
@@ -408,43 +421,13 @@
 
 				if (target && target.dataset.id) {
 					const itemId = target.dataset.id
-
-					switch (itemId) {
-						case 'vacuum-cleaner-Tab':
-							getItems(itemId)
-							break
-						case 'hairdryer-Tab':
-							getItems(itemId)
-							break
-						case 'topaz-Tab':
-							getItems(itemId)
-							break
-						case 'hd07-Tab':
-							getItems(itemId)
-							break
-						case 'purifier-Tab':
-							getItems(itemId)
-							break
-						case 'styler-Tab':
-							getItems(itemId)
-							break
-						case 'hs05-Tab':
-							getItems(itemId)
-							break
-					}
+					const filtered = allSlides.filter(slide =>
+						slide.classList.contains(itemId)
+					)
+					rebuildSwiperWithSlides(filtered)
 				}
 			})
 		}
 		filterTabs()
-
-		function getItems(tabName) {
-			items.forEach(item => {
-				if (item.classList.contains(tabName)) {
-					item.style.display = 'block'
-				} else {
-					item.style.display = 'none'
-				}
-			})
-		}
 	})
 })()


### PR DESCRIPTION
Adapts tab filtering in `main.js` to use Swiper for dynamic slide management.

The previous tab filtering logic manually hid/showed DOM elements, which is incompatible with Swiper's dynamic slide management and pagination. This change destroys and reinitializes the Swiper instance with only the slides relevant to the selected tab, ensuring correct behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-430fe9db-e686-4444-a29c-304deee75cad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-430fe9db-e686-4444-a29c-304deee75cad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

